### PR TITLE
【Fixed】メニュー作成画面で、プリセット・オリジナルのタブ切り替えで種目を表示する

### DIFF
--- a/app/assets/stylesheets/menu.scss
+++ b/app/assets/stylesheets/menu.scss
@@ -1,9 +1,17 @@
-.menu-wrapper {
-  width: 500px;
+.menu {
+  &-container {
+    width: 600px;
+    margin: 0 auto;
+    margin-top: 20px;
+  }
 
-  .menu {
+  &-wrapper {
+    width: 600px;
+  }
+
+  &-content {
     background-color: #f7f7f7;
-    padding: 10px;
+    padding: 20px;
     margin-bottom: 20px;
     box-shadow: 0 2px 6px #c1ced7;
 
@@ -42,9 +50,9 @@
       }
     }
   }
-}
 
-.menu-new-footer {
-  display: flex;
-  justify-content: space-between;
+  &-new-footer {
+    display: flex;
+    justify-content: space-between;
+  }
 }

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,5 +1,6 @@
 class MenusController < ApplicationController
   before_action :set_menu, only: %i[show edit update destroy]
+  before_action :set_exercises, only: %i[new create edit update]
 
   def index
     @menus = Menu.where(user: current_user)
@@ -44,5 +45,10 @@ class MenusController < ApplicationController
 
   def set_menu
     @menu = Menu.find(params[:id])
+  end
+
+  def set_exercises
+    @exercises_preset = Exercise.preset
+    @exercises_original = Exercise.original
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -4,4 +4,7 @@ class Menu < ApplicationRecord
   belongs_to :user
   has_many :menu_relationships, dependent: :destroy
   has_many :exercises, through: :menu_relationships, source: :exercise
+
+  scope :preset, -> { where(preset: true) }
+  scope :original, -> { where(preset: false) }
 end

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -1,12 +1,7 @@
-<div class="col-6 mx-auto">
-  <div class="mt-3">
+<div class="menu-container">
+  <div class="page-title">
     <h1>トレーニングメニュー編集</h1>
-
-    <div>
-      <%= link_to '< 戻る', :back, class: 'btn btn-link' %>
-      <%= link_to '一覧 >', menus_path, class: 'btn btn-link' %>
-    </div>
-
-    <%= render 'partial/menu_form', menu: @menu %>
   </div>
+
+  <%= render 'partial/menu/menu_form', { menu: @menu, exercises_preset: @exercises_preset, exercises_original: @exercises_original } %>
 </div>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,4 +1,4 @@
-<div class="main-container">
+<div class="menu-container">
   <h1 class="page-title mb-4">トレーニングメニュー</h1>
 
   <% if @menus.empty? %>
@@ -15,13 +15,13 @@
 
   <div class="menu-wrapper">
     <% @menus.each do |menu| %>
-      <div class="menu">
-        <div class="menu-header">
-          <h2 class="menu-header-name">
+      <div class="menu-content">
+        <div class="menu-content-header">
+          <h2 class="menu-content-header-name">
             <%= link_to menu.name, menu_path(menu) %>
           </h2><!-- /.list_header_title -->
 
-          <div class="menu-header-action">
+          <div class="menu-content-header-action">
             <%= link_to content_tag(:i, '', class: 'fas fa-pen'), edit_menu_path(menu) %>
             <%= link_to content_tag(:i, '', class: 'fas fa-trash'), menu_path(menu), method: :delete, data: { confirm: "#{menu.name}を削除してよろしいですか？" } %>
           </div>
@@ -30,9 +30,9 @@
         <p class="mb-2">インターバル : <%= menu.interval %>日</p>
 
         <% menu.exercises.each do |exercise| %>
-          <div class="menu-index-item">
-            <i class="fas fa-dumbbell fa-2x mr-3"></i>
-              <%= link_to exercise.name, workouts_path(id: exercise.id), class: 'menu-index-item-name' %>
+          <div class="menu-content-index-item">
+            <%= image_tag '16765.png', alt: 'トレーニングアイコン', size: '50', class: 'mr-3' %>
+              <%= link_to exercise.name, workouts_path(id: exercise.id), class: 'menu-content-index-item-name' %>
           </div>
         <% end %>
       </div><!-- /.menu -->

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -1,7 +1,7 @@
-<div class="main-container">
-  <div class="page-title mb-3">
+<div class="menu-container">
+  <div class="page-title mb-4">
     <h1>トレーニングメニュー作成</h1>
   </div>
 
-  <%= render 'partial/menu_form', menu: @menu %>
+  <%= render 'partial/menu/menu_form', { menu: @menu, exercises_preset: @exercises_preset, exercises_original: @exercises_original } %>
 </div>

--- a/app/views/partial/menu/_menu_form.html.erb
+++ b/app/views/partial/menu/_menu_form.html.erb
@@ -21,26 +21,20 @@
       <%= f.select :interval, [1, 2, 3, 4, 5], { include_brank: '選択してください' }, class: 'form-control', id: 'menu_interval' %>
     </div><!-- /.form-group -->
 
-    <table class="table table-hover">
-      <tbody>
-        <% Exercise.all.each do |exercise| %>
-          <tr>
-            <td>
-              <%= f.check_box :exercise_ids, {
-                multiple: true, checked: @menu.exercises.find_by(id: exercise.id).present?, include_hidden: false
-              }, exercise[:id] %>
-            </td>
-            <td><%= image_tag '16765.png', alt: 'トレーニングアイコン', size: '50' %></td>
-            <td><%= exercise.name %></td>
-            <td><%= exercise.part_i18n %></td>
-            <td><%= exercise.category_i18n %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <div class="tab-wrap">
+      <input id="TAB-01" type="radio" name="TAB" class="tab-switch" checked="checked" /><label class="tab-label" for="TAB-01">プリセット</label>
+      <div class="tab-content">
+        <%= render 'partial/menu/menu_form_content', { f: f, exercises: exercises_preset } %>
+      </div>
+
+      <input id="TAB-02" type="radio" name="TAB" class="tab-switch" /><label class="tab-label" for="TAB-02">オリジナル</label>
+      <div class="tab-content">
+        <%= render 'partial/menu/menu_form_content', { f: f, exercises: exercises_original } %>
+      </div>
+    </div><!-- /.tab-wap -->
 
     <div class="menu-new-footer">
-      <%= link_to '戻る', menus_path, class: 'btn btn-secondary text-white' %>
+      <%= link_to '戻る', menus_path, class: 'btn btn-outline-secondary' %>
       <%= f.submit nil, class: 'btn btn-primary' %>
     </div>
   <% end %>

--- a/app/views/partial/menu/_menu_form_content.html.erb
+++ b/app/views/partial/menu/_menu_form_content.html.erb
@@ -1,0 +1,15 @@
+<table class="table table-hover">
+    <% exercises.each do |exercise| %>
+      <tbody>
+        <tr>
+          <td class="align-middle"><%= f.check_box :exercise_ids, {
+              multiple: true, checked: @menu.exercises.find_by(id: exercise.id).present?, include_hidden: false
+            }, exercise[:id], id: exercise.id %></td>
+          <td class="align-middle"><label for="menu_exercise_ids_<%= exercise.id %>"><%= image_tag '16765.png', alt: 'トレーニングアイコン', size: '50' %></label></td>
+          <td class="align-middle"><label for="menu_exercise_ids_<%= exercise.id %>"><%= exercise.name %></label></td>
+          <td class="align-middle"><label for="menu_exercise_ids_<%= exercise.id %>"><%= exercise.part_i18n %></label></td>
+          <td class="align-middle"><label for="menu_exercise_ids_<%= exercise.id %>"><%= exercise.category_i18n %></label></td>
+        </tr>
+      </tbody>
+    <% end %>
+</table>


### PR DESCRIPTION
#38

- プリセット・オリジナルのタブ切り替えで種目を表示する
- 新規・編集時のバリデーションチェック時のエラーを修正