### PR TITLE
【Fixed】投稿へのコメント投稿者名が正しく表示されない

### DIFF
--- a/app/views/partial/_post_content.html.erb
+++ b/app/views/partial/_post_content.html.erb
@@ -2,8 +2,10 @@
   <div class="content-header">
     <!-- ユーザー情報 -->
     <p><%= image_tag set_image(post.user.profile.icon, 'default_user_icon.png'), alt: post.user.name, class: 'cover50' %></p>
-
-    <%= render 'partial/post_name_and_created_time', post: post %>
+    <div class="post-names">
+      <p class="post-user"><%= post.user.name %></p>
+      <p class="post-time"><%= format_date_time(post.created_at) %></p>
+    </div>
 
     <!-- 詳細表示リンク -->
       <%= link_to content_tag(:i, '', class: 'fas fa-info-circle fa-1_5x fa-fw mr-2 post-icon'), post_path(post) %>

--- a/app/views/partial/_post_name_and_created_time.html.erb
+++ b/app/views/partial/_post_name_and_created_time.html.erb
@@ -1,5 +1,0 @@
-<!-- 投稿者の名前と投稿時間 -->
-<div class="post-names">
-  <p class="post-user"><%= post.user.name %></p>
-  <p class="post-time"><%= format_date_time(post.created_at) %></p>
-</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,8 +22,10 @@
       <div class="post-comment">
         <div class="content-header">
           <p><%= image_tag set_image(comment.user.profile.icon, 'default_user_icon.png'), alt: comment.user.name, class: 'cover50' %></p>
-
-          <%= render 'partial/post_name_and_created_time', post: @post %>
+          <div class="post-names">
+            <p class="post-user"><%= comment.user.name %></p>
+            <p class="post-time"><%= format_date_time(comment.created_at) %></p>
+          </div>
 
           <% if comment.user.id == current_user.id %>
             <div class="post-icons">


### PR DESCRIPTION
#103 
- 投稿者と投稿時刻をパーシャル化したので、不具合が出た。そのためコードを元に戻した。