### PR TITLE
【Fixed】ユーザーにわかりにくい部分を修正 + その他微調整

### DIFF
--- a/app/assets/stylesheets/body_statuses.scss
+++ b/app/assets/stylesheets/body_statuses.scss
@@ -4,3 +4,17 @@
   height: auto;
   background-color: #fff;
 }
+
+.edit-profile-link {
+  text-decoration: underline;
+}
+
+.body {
+  &-weight-required {
+  color: red;
+  }
+
+  &-fat-option {
+    color: gray;
+  }
+}

--- a/app/assets/stylesheets/calendar.scss
+++ b/app/assets/stylesheets/calendar.scss
@@ -19,7 +19,7 @@
 }
 
 .calendar_name {
-  font-size: 18px;
+  font-size: 30px;
   margin-top: 20px;
   background-color: #43cd58;
   color: #fff;

--- a/app/assets/stylesheets/post.scss
+++ b/app/assets/stylesheets/post.scss
@@ -14,6 +14,13 @@
   margin-bottom: 10px;
 }
 
+.post-picture-area {
+  width: auto;
+  max-width: 100%;
+  box-sizing: border-box;
+  height: auto;
+}
+
 .post-main-content {
   background-color: #fff;
   border: 1px solid #ebebeb;
@@ -22,13 +29,20 @@
   margin-top: 20px;
 }
 
+.post-picture-label {
+  padding: 15px 15px 5px;
+}
+
 .post-picture-content {
-  padding: 15px;
   background-color: #fff;
   border: 1px solid #ebebeb;
   border-radius: 3px;
   margin-bottom: 20px;
   margin-top: 20px;
+}
+
+.post-picture-select {
+  padding: 15px 15px 5px;
 }
 
 .user-container {
@@ -105,21 +119,8 @@
   background: #fff;
   border-radius: 3px;
 }
+
 .comment-content {
   margin-left: 65px;
   white-space: pre-wrap;
-}
-
-.post-picture {
-  object-fit: cover;
-  width: 100%;
-  height: auto;
-  background-color: #fff;
-}
-
-.post-picture-form {
-  object-fit: cover;
-  width: 300px;
-  height: auto;
-  background-color: #fff;
 }

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -38,13 +38,14 @@ class ExercisesController < ApplicationController
 
   def search
     @search_params = exercise_search_params
+    @exercises_preset = Exercise.exercise_search(@search_params)
 
-    if @search_params[:name].blank? && @search_params[:part].blank? && @search_params[:category].blank?
-      set_exercise_preset_and_original
-    else
-      @search_params[:preset] = true
-      @exercises_preset = Exercise.exercise_search(@search_params)
-    end
+    # if @search_params[:name].blank? && @search_params[:part].blank? && @search_params[:category].blank?
+    #   set_exercise_preset_and_original
+    # else
+      # @search_params[:preset] = true
+      # @exercises_preset = Exercise.exercise_search(@search_params)
+    # end
 
     render :index
   end
@@ -69,7 +70,7 @@ class ExercisesController < ApplicationController
 
   def set_exercise_preset_and_original
     @exercises_preset = Exercise.preset
-    @exercises_original = Exercise.original
+    @exercises_original = Exercise.original(current_user)
   end
 
   def exercise_search_params

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -50,6 +50,6 @@ class MenusController < ApplicationController
 
   def set_exercises
     @exercises_preset = Exercise.preset
-    @exercises_original = Exercise.original
+    @exercises_original = Exercise.original(current_user)
   end
 end

--- a/app/controllers/workout_logs_controller.rb
+++ b/app/controllers/workout_logs_controller.rb
@@ -24,6 +24,6 @@ class WorkoutLogsController < ApplicationController
   end
 
   def workout_logs_search_params
-    params.fetch(:search, {}).permit(:name)
+    params.fetch(:search, {}).permit(:name, :user_id)
   end
 end

--- a/app/models/body_status.rb
+++ b/app/models/body_status.rb
@@ -11,9 +11,9 @@ class BodyStatus < ApplicationRecord
   paginates_per 14
 
   def self.get_bmi(height, weight)
-    return if height.blank?
+    return if height.blank? || height <= 0.0
 
-    (weight / (height / 100) ** 2).floor
+    (weight / (height / 100) ** 2).floor(2)
   end
 
   scope :get_body_status_records, -> (current_user, range, column) do

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -27,16 +27,15 @@ class Exercise < ApplicationRecord
   }
 
   scope :preset, -> { where(preset: true) }
-  scope :original, -> { where(preset: false) }
+  scope :original, -> (current_user) { where(preset: false).where(user_id: current_user.id) }
 
   scope :exercise_search, -> (search_params) do
-    if search_params[:name].present?
-      name_like(search_params[:name])
-    elsif search_params[:part].present?
-      preset_is.part_is(search_params[:part])
-    elsif search_params[:category].present?
-      preset_is.category_is(search_params[:category])
-    end
+    return if search_params.blank?
+
+    where(preset: true)
+      .name_like(search_params[:name])
+      .part_is(search_params[:part])
+      .category_is(search_params[:category])
   end
 
   scope :name_like, -> (name) { where('name LIKE ?', "%#{name}%") if name.present? }

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -20,13 +20,17 @@ class Workout < ApplicationRecord
 
   scope :search_workout, -> (search_params) do
     if search_params[:name].blank?
-      order(created_at: :desc)
+      find_workout_logs_by_user_id(search_params)
     else
       exercise = Exercise.find_by(name: search_params[:name])
-      return order(created_at: :desc) if exercise.nil?
+      return find_workout_logs_by_user_id(search_params) if exercise.nil?
 
       where(exercise_id: exercise.id).order(created_at: :desc)
     end
+  end
+
+  scope :find_workout_logs_by_user_id, -> (search_params) do
+    where(user_id: search_params[:user_id]).order(created_at: :desc)
   end
 
   scope :get_workout_records, -> (user, exercise_id, range, column) do

--- a/app/views/body_statuses/index.html.erb
+++ b/app/views/body_statuses/index.html.erb
@@ -25,14 +25,21 @@
         <tr>
           <td><%= link_to format_date_time(body_status.created_at), body_status_path(body_status), class: 'body-status' %></td>
           <td><%= body_status.body_weight %></td>
-          <td><%= body_status.body_fat %></td>
+
+          <% if body_status.body_fat.present? %>
+            <td><%= body_status.body_fat %></td>
+          <% else %>
+            <td>-</td>
+          <% end %>
+
           <% unless @height.blank? %>
             <td><%= BodyStatus.get_bmi(@height, body_status.body_weight) %></td>
           <% else %>
             <td>-</td>
           <% end %>
-          <td><%= link_to '編集', edit_body_status_path(body_status), class: 'btn-sm btn-success text-white' %></td>
-          <td><%= link_to '削除', body_status_path(body_status), method: :delete, data: { confirm: '削除してもよろしいですか？' }, class: 'btn-sm btn-danger text-white' %></td>
+
+          <td><%= link_to content_tag(:i, '', class: 'fas fa-pen menu-icon'), edit_body_status_path(body_status) %></td>
+          <td><%= link_to content_tag(:i, '', class: 'fas fa-trash menu-icon'), body_status_path(body_status), method: :delete, data: { confirm: '記録を削除してよろしいですか？' } %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/body_statuses/show.html.erb
+++ b/app/views/body_statuses/show.html.erb
@@ -12,7 +12,11 @@
     </tr>
     <tr>
       <th>体脂肪</th>
-      <td><%= @body_status.body_fat %> %</td>
+      <% if @body_status.body_fat.present? %>
+        <td><%= @body_status.body_fat %> %</td>
+      <% else %>
+        <td>-</td>
+      <% end %>
     </tr>
     <tr>
       <th>BMI</th>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -2,9 +2,9 @@
   <h1 class="page-title">カレンダー</h1>
 
   <% if controller.controller_name == 'menus'%>
-    <p class="calendar_name"><%= current_user.name %></p>
+    <h2 class="calendar_name"><%= current_user.name %></h2>
   <% else %>
-    <p class="calendar_name"><%= @user.name %></p>
+    <h2 class="calendar_name"><%= @user.name %></h2>
   <% end %>
 
   <div class="mt-3">

--- a/app/views/partial/_body_status_form.html.erb
+++ b/app/views/partial/_body_status_form.html.erb
@@ -16,15 +16,27 @@
       <%= f.datetime_select :created_at, {}, value: Time.now.strftime("%Y-%m-%d") %>
     </div><!-- /.form-group -->
 
+    <div>
+        <label>身長</label>
+        <% if current_user.profile.height.nil? %>
+          <p>未設定です。<%= link_to 'プロフィール編集', edit_profile_path(current_user), class: 'edit-profile-link' %>で身長を入力してください</p>
+        <% else %>
+          <%= current_user.profile.height %> cm
+          <p><%= link_to '身長を変更', edit_profile_path(current_user), class: 'edit-profile-link' %></p>
+        <% end %>
+      </div>
+
     <div class="form-group mt-4">
       <%= f.label :body_weight %>
+      <p class="body-weight-required">&nbsp;(必須)</p>
       <%= f.number_field :body_weight, min: 1, max:150, step:0.1, class: 'form-control' %>
     </div><!-- /.form-group -->
 
     <div class="form-group">
       <%= f.label :body_fat %>
+      <p class="body-fat-option">&nbsp;(オプション)</p>
       <%= f.number_field :body_fat, min: 1, max:50, step:0.1, class: 'form-control' %>
-    </div><!-- /.form-group -->
+</div><!-- /.form-group -->
 
     <%# 写真1 %>
     <div class="form-group mb-2 picture-upload-area">

--- a/app/views/partial/_footer.html.erb
+++ b/app/views/partial/_footer.html.erb
@@ -6,6 +6,7 @@
           <li><%= link_to content_tag(:i, '', class: 'fas fa-chart-line fa-2x ml-4 footer-icon'), charts_path({id: 0, range: 'all', user_id: current_user.id}) %></li>
           <li><%= link_to content_tag(:i, '', class: 'far fa-file fa-2x ml-4 footer-icon'), workout_logs_path(id: current_user) %></li>
           <li><%= link_to content_tag(:i, '', class: 'far fa-calendar-alt fa-2x ml-4 footer-icon'), calendar_path(current_user.id) %></li>
+          <li><%= link_to content_tag(:i, '', class: 'fas fa-user-cog fa-2x ml-4 footer-icon'), profile_path(current_user) %></li>
         </ul>
       </ul>
     </nav>

--- a/app/views/partial/_post_content.html.erb
+++ b/app/views/partial/_post_content.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <!-- 詳細表示リンク -->
-      <%= link_to content_tag(:i, '', class: 'fas fa-info-circle fa-1_5x fa-fw mr-2 post-icon'), post_path(post) %>
+      <%= link_to content_tag(:i, '', class: 'fas fa-info-circle fa-1_5x fa-fw mr-2 post-icon'), post_path(post) unless action_name == 'show' %>
 
     <% if post.user.id == current_user.id %>
       <div class="post-icons">
@@ -24,9 +24,9 @@
     <p class="post-content"><%= post.content %></p>
   </div><!-- /.content-body -->
 
-  <div class="picture-area">
-    <p class="mb-2"><%= image_tag post.picture.url, alt: '投稿写真', class: 'post-picture' if post.picture.present? %></p>
-  </div><!-- /.picture-area -->
+  <div>
+    <p><%= image_tag post.picture.url, alt: '投稿写真', class: 'post-picture-area' if post.picture.present? %></p>
+  </div>
 
     <div class="content-footer">
       <!-- いいね, コメントアイコン -->

--- a/app/views/partial/_post_form.html.erb
+++ b/app/views/partial/_post_form.html.erb
@@ -14,7 +14,11 @@
   <div class="post-main-content">
     <div class="form-group">
       <div class="time-area">
-        <%= format_date_time(Time.zone.now) %>
+        <% if action_name == 'new' %>
+          <%= format_date_time(Time.zone.now) %>
+        <% elsif action_name == 'edit' %>
+          <%= format_date_time(@post.created_at) %>
+        <% end %>
       </div><!-- /.time-area -->
 
       <div class="content-header">

--- a/app/views/partial/exercise/_exercise_content.html.erb
+++ b/app/views/partial/exercise/_exercise_content.html.erb
@@ -6,7 +6,7 @@
         <td class="align-middle"><%= link_to exercise.name, exercise_path(exercise) %></td>
         <td class="align-middle"><%= exercise.part_i18n %></td>
         <td class="align-middle"><%= exercise.category_i18n %></td>
-        <td class="align-middle"><%= link_to '編集', edit_exercise_path(exercise), class: 'btn btn-success btn-sm text-white' if exercise.user.id == current_user.id %></td>
+        <td class="align-middle"><%= link_to content_tag(:i, '', class: 'fas fa-pen menu-icon'), edit_exercise_path(exercise) if exercise.user_id == current_user.id %></td>
       </tr>
     </tbody>
   <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -51,7 +51,7 @@
       <%# 身長 %>
       <div class="form-group">
         <%= f.label :height %>
-        <%= f.number_field :height, min: 0, max:250, step:0.1, class: 'form-control' %>
+        <%= f.number_field :height, min: 100, max:250, step:0.1, class: 'form-control' %>
       </div><!-- /.form-group -->
 
       <%# 自己紹介 %>
@@ -60,7 +60,8 @@
         <%= f.text_area :self_introduction, rows: 5, class: 'form-control' %>
       </div><!-- /.form-group -->
 
-      <div class="one-submit">
+      <div class="two-submit">
+        <%= link_to '戻る', :back, class: 'btn btn-outline-secondary' %>
         <%= f.submit class: 'btn btn-primary' %>
       </div><!-- /.one-submit -->
     <% end %><!-- ./form-with -->

--- a/app/views/workout_logs/index.html.erb
+++ b/app/views/workout_logs/index.html.erb
@@ -1,7 +1,7 @@
 <div class="workout_logs-container">
   <h1 class="page-title">トレーニング記録一覧</h1>
 
-  <p class="calendar_name mb-4"><%= @user.name %></p>
+  <h2 class="calendar_name mb-4"><%= @user.name %></h2>
 
   <%= render '/partial/search_workout_log' %>
 

--- a/app/views/workouts/index.html.erb
+++ b/app/views/workouts/index.html.erb
@@ -25,12 +25,12 @@
       <tbody>
         <% @workouts.each do |workout| %>
           <tr>
-            <td><%= link_to format_date(workout.created_at), workout_path(workout) %>
+            <td><%= link_to format_date(workout.created_at), workout_path(workout), class: 'workout-date' %></td>
             <td class="text-center"><%= workout.set %></td>
             <td class="text-right pr-4"><%= workout.max_weight.round(1) %></td>
             <td class="text-right pr-5"><%= workout.max_one_rm.round(1) %></td>
             <td class="text-right pr-5"><%= workout.total_weight.round(1) %></td>
-            <td><%= link_to '編集', edit_workout_path(workout), class: 'btn btn-success btn-sm text-white' %></td>
+            <td><%= link_to content_tag(:i, '', class: 'fas fa-pen menu-icon'), edit_workout_path(workout) %></td>
           </tr>
         <% end %><!-- /@worktous.each do |menu| -->
       </tbody>

--- a/spec/models/exercise_log_spec.rb
+++ b/spec/models/exercise_log_spec.rb
@@ -97,11 +97,11 @@ RSpec.describe 'exercise_logに関するテスト', type: :model do
 
     context '種目をoriginalで検索した場合' do
       it 'ユーザーが独自に登録した種目を返すこと' do
-        expect(Exercise.original).to include(exercise2)
+        expect(Exercise.original(user_b)).to include(exercise2)
       end
 
       it 'デフォルトで登録されている種目を返さないこと' do
-        expect(Exercise.original).not_to include(exercise)
+        expect(Exercise.original(user_b)).not_to include(exercise)
       end
     end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe 'トレーニング種目に関するテスト', type: :model do
 
     context '種目をoriginalで検索した場合' do
       it 'ユーザーが独自に登録した種目を返すこと' do
-        expect(Exercise.original).to include(exercise2)
+        expect(Exercise.original(user_b)).to include(exercise2)
       end
 
       it 'デフォルトで登録されている種目を返さないこと' do
-        expect(Exercise.original).not_to include(exercise)
+        expect(Exercise.original(user_b)).not_to include(exercise)
       end
     end
 

--- a/spec/system/body_statuses_spec.rb
+++ b/spec/system/body_statuses_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe '体重・体脂肪', type: :system do
         let(:login_user) { user_a }
 
         before do
-          click_on '編集'
+          all('.menu-icon')[0].click
           fill_in '体重', with: 80
           fill_in '体脂肪', with: 15.0
           click_on '更新する'
@@ -79,7 +79,7 @@ RSpec.describe '体重・体脂肪', type: :system do
         let(:login_user) { user_a }
 
         before do
-          click_on '削除'
+          all('.menu-icon')[1].click
         end
 
         it '体重記録が削除されていること' do

--- a/spec/system/exercises_spec.rb
+++ b/spec/system/exercises_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'トレーニング種目', type: :system do
         let(:login_user) { user_a }
 
         before do
-          click_on '編集'
+          all('.menu-icon')[0].click
           select 'その他', from: '部位'
           select 'マシン', from: 'カテゴリー'
           fill_in '説明', with: '編集テストです。'

--- a/spec/system/menus_spec.rb
+++ b/spec/system/menus_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'トレーニングメニュー', type: :system do
   describe '管理機能' do
     let(:user_a) { create(:user, name: 'ユーザーA', email: 'a@example.com', admin: true) }
     let(:user_b) { create(:user, name: 'ユーザーB', email: 'b@example.com', admin: false) }
-    let!(:exercise) { create(:exercise, name: 'ベンチプレス', user: user_a) }
+    let!(:exercise) { create(:exercise, name: 'ベンチプレス', preset: true, user: user_a) }
     let!(:exercise2) { create(:exercise2, name: 'スクワット', preset: true, user: user_a) }
     let!(:exercise3) { create(:exercise3, name: 'ダンベルベンチプレス', user: user_a) }
     let!(:exercise4) { create(:exercise4, name: 'チェストプレス', user: user_a) }

--- a/spec/system/workouts_spec.rb
+++ b/spec/system/workouts_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'トレーニング記録', type: :system do
     end
 
     describe '新規作成' do
-      context '種目のリンクを押したとき' do
+      context 'トレーニング記録を作成したとき' do
         let(:login_user) { user }
 
         before do
@@ -44,12 +44,66 @@ RSpec.describe 'トレーニング記録', type: :system do
           click_on '登録する'
         end
 
-        it 'トレーニング記録の一覧が表示されていること' do
+        it '作成したトレーニング記録が表示されていること' do
           expect(page).to have_content '記録しました'
           expect(page).to have_content 'ベンチプレス'
         end
       end
     end
+
+    describe '詳細表示' do
+      context '日付のリンクを押したとき' do
+        let(:login_user) { user }
+
+        before do
+          all('.workout-date')[0].click
+        end
+
+        it 'トレーニング記録の詳細が表示されていること' do
+          expect(page).to have_content 'ベンチプレス'
+          expect(page).to have_content '62.5'
+        end
+      end
+    end
+
+    describe '編集' do
+      context 'トレーニング記録を編集したとき' do
+        let(:login_user) { user }
+
+        before do
+          sleep 0.1
+          all('.menu-icon')[0].click
+          fill_in 'workout_exercise_logs_attributes_0_weight', with: 70.0
+          fill_in 'workout_exercise_logs_attributes_0_rep', with: 8
+          click_on '更新する'
+        end
+
+        it 'トレーニング記録が更新されていること' do
+          expect(page).to have_content '更新しました'
+        end
+      end
+    end
+
+    describe '削除' do
+      context '削除リンクを押したとき' do
+        let(:login_user) { user }
+
+        before do
+          all('.workout-date')[0].click
+          click_on '削除'
+        end
+
+        it 'トレーニング記録が削除されていること' do
+          expect do
+            page.accept_confirm do
+              click_on :delete_button
+            end
+            expect(page).to have_content '削除しました'
+          end
+        end
+      end
+    end
+
 
     describe '入力フォームの削除' do
       context '入力フォームを最後の1つまで削除したとき' do


### PR DESCRIPTION
#107 
- 体重記録フォームに身長設定へのリンクを追加
- 投稿画面のimageの表示サイズを調整
- BMIを小数第2位まで表示に変更
- フッターにプロフィール画面へのリンクを追加
- 画面レイアウトの変更
- 身長入力のバリデーションを修正
- トレーニング記録、種目の検索ロジックを修正
- 投稿時刻が正しく表示されるように修正
- 検索ロジック変更及び、画面レイアウト変更に関連するシステムテストを修正