### PR TITLE
【Fixed】グラフのデータが存在しない場合のエラーを修正

### DIFF
--- a/app/models/body_status.rb
+++ b/app/models/body_status.rb
@@ -25,10 +25,20 @@ class BodyStatus < ApplicationRecord
   end
 
   scope :get_chart_min, -> (current_user, range, column) do
-    find_body_status(current_user, range).pluck(column).min - 1
+    arr = find_body_status(current_user, range).pluck(column)
+    unless arr.empty?
+      arr.min - 1
+    else
+      0
+    end
   end
 
   scope :get_chart_max, -> (current_user, range, column) do
-    find_body_status(current_user, range).pluck(column).max + 1
+    arr = find_body_status(current_user, range).pluck(column)
+    unless arr.empty?
+      arr.max + 1
+    else
+      0
+    end
   end
 end

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -10,11 +10,15 @@
 
   <% if @exercise_id == '0' %>
     <!-- 体重・体脂肪のグラフ -->
-    <%= render 'partial/chart_body_status', {
-      range_title: @range_title,
-      chart_records: @chart_records,
-      chart_values: @chart_values
-    } %>
+    <% unless @chart_values.has_value?(0) %>
+      <%= render 'partial/chart_body_status', {
+        range_title: @range_title,
+        chart_records: @chart_records,
+        chart_values: @chart_values
+      } %>
+    <% else %>
+      <p class="text-center mt-4">データが存在しません</p>
+    <% end %>
   <% else %>
   <!-- トレーニングのグラフ -->
     <%= render 'partial/chart_workout', {


### PR DESCRIPTION
#130 

- グラフのデータが存在しない場合、'データが存在しません'という文言を表示
- 表示は期間のタイトル下とした
![スクリーンショット 2020-06-24 22 33 22](https://user-images.githubusercontent.com/50142017/85566357-f0be1880-b66a-11ea-8bf2-2f9866e2c713.png)
 