### PR TITLE
【Fixed】footerをウィンドウ表示領域の下端に固定して、常に表示する

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -267,3 +267,7 @@ select {
   text-align: center;
   margin-bottom: 30px;
 }
+
+.top-wrapper {
+  margin-bottom: 100px;
+}

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,27 +1,7 @@
-/* Sticky footer styles
--------------------------------------------------- */
-html {
-  position: relative;
-  min-height: 100%;
-}
-
-body {
-  /* Margin bottom by footer height */
-  margin-bottom: 60px;
-}
-
 .footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  /* Set the fixed height of the footer here */
-  height: 60px;
   background-color: #e9e9e9;
 }
 
-/* Custom page CSS
--------------------------------------------------- */
-/* Not required for template or sticky footer method. */
 .container {
   width: auto;
   max-width: 600px;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,12 +1,8 @@
 .header {
   padding: 10px 20px;
   height: 80px;
-  background-color: #fff;
-  border-bottom: 1px solid #ccc;
-  position: sticky;
-  top: 0;
   background-color: #2e2e2e;
-  z-index: 99;
+
 
   a {
     color: #fff;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@
       </div>
     <% end %>
 
-    <%= yield %>
+    <div class="top-wrapper">
+      <%= yield %>
+    </div><!-- /.top-wrapper -->
 
     <%= render 'partial/footer' if current_user%>
   </body>

--- a/app/views/partial/_footer.html.erb
+++ b/app/views/partial/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer class="footer fixed-bottom">
   <div class="container">
     <nav class="text-muted">
       <ul class="footer-menu">

--- a/app/views/partial/_header.html.erb
+++ b/app/views/partial/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="header">
+<header class="header sticky-top">
   <nav class="header-nav">
     <ul class="header-menu">
       <li class="header-menu-title"><%= link_to 'My fitness', menus_path %></li>


### PR DESCRIPTION
#132 

- footerをウィンドウ下端に固定して、常に表示するように変更。ウィンドウのサイズが変わっても追従して動く
- headerはすでにウィンドウ上端に固定されていたが、Bootstrap4のclassを用いてよりシンプルな実装に変更した

![スクリーンショット 2020-06-24 23 26 38](https://user-images.githubusercontent.com/50142017/85575087-3f22e580-b672-11ea-8802-a7605666e58d.png)
