### PR TITLE
【Fixed】headerとfooterのデザインを変更

### DIFF
--- a/app/assets/javascripts/current_page.js
+++ b/app/assets/javascripts/current_page.js
@@ -1,0 +1,35 @@
+$(document).on('turbolinks:load', function () {
+  var path = location.pathname;
+
+  // headerのメニュー項目
+  if (path.match('menus')) {
+    $('.header-menu-inner .menu1').addClass('current-h').css('pointer-events', 'none');
+  }
+  if (path.match('exercises')) {
+    $('.header-menu-inner .menu2').addClass('current-h').css('pointer-events', 'none');
+  }
+  if (path === '/profiles') {
+    $('.header-menu-inner .menu3').addClass('current-h').css('pointer-events', 'none');;
+  }
+
+  if (path.match('posts')) {
+    $('.header-menu-inner .menu4').addClass('current-h').css('pointer-events', 'none');;
+  }
+
+  // footerのメニュー項目
+  if (path.match('body')) {
+    $('.footer-menu .menu1').addClass('current-f').css('pointer-events', 'none');
+  }
+  if (path.match('charts')) {
+    $('.footer-menu .menu2').addClass('current-f').css('pointer-events', 'none');
+  }
+  if (path.match('workout_logs')) {
+    $('.footer-menu .menu3').addClass('current-f').css('pointer-events', 'none');
+  }
+  if (path.match('calendar')) {
+    $('.footer-menu .menu4').addClass('current-f').css('pointer-events', 'none');
+  }
+  if (path.match('profiles/')) {
+    $('.footer-menu .menu5').addClass('current-f').css('pointer-events', 'none');
+  }
+});

--- a/app/assets/stylesheets/body_statuses.scss
+++ b/app/assets/stylesheets/body_statuses.scss
@@ -1,3 +1,8 @@
+.body-statuses-container {
+  width: 600px;
+  margin: 0 auto;
+}
+
 .pic_prev {
   object-fit: cover;
   width: 200px;

--- a/app/assets/stylesheets/chart.scss
+++ b/app/assets/stylesheets/chart.scss
@@ -1,3 +1,8 @@
+.charts-container {
+  width: 600px;
+  margin: 0 auto;
+}
+
 .chart-nav-container {
   width: 100%;
 }

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,19 +1,22 @@
 .footer {
+  width: 100%;
   background-color: #e9e9e9;
 }
 
-.container {
-  width: auto;
-  max-width: 600px;
-  padding: 0 15px;
+.footer-menu {
+  display: flex;
+  justify-content: space-between;
+  text-align: center;
+  width: 50%;
+  padding: 10px;
+  margin: 0 auto;
+}
 
-  .text-muted {
-    margin: 10px 0;
-    padding-top: 5px;
+.footer-menu li > .content:before {
+  display: block;
+  content: '';
+}
 
-    .footer-menu {
-      display: flex;
-      justify-content: space-evenly;
-    }
-  }
+.active-f {
+  border-bottom: 3px solid #333333;
 }

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,22 +1,34 @@
 .footer {
   width: 100%;
   background-color: #e9e9e9;
+
+  &-menu {
+    display: flex;
+    justify-content: space-between;
+    text-align: center;
+    width: 50%;
+    padding: 10px;
+    margin: 0 auto;
+
+    a {
+      text-decoration: none;
+      padding-bottom: 3px;
+    }
+
+    a:hover {
+      border-bottom: 3px solid #333333;
+      transition: all 0.3s ease 0s;
+      padding-bottom: 0;
+    }
+
+    li > .content:before {
+      display: block;
+      content: '';
+    }
+  }
 }
 
-.footer-menu {
-  display: flex;
-  justify-content: space-between;
-  text-align: center;
-  width: 50%;
-  padding: 10px;
-  margin: 0 auto;
-}
-
-.footer-menu li > .content:before {
-  display: block;
-  content: '';
-}
-
-.active-f {
-  border-bottom: 3px solid #333333;
+.current-f {
+  border-bottom: 3px solid #da5019;
+  padding-bottom: 3px;
 }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -30,11 +30,20 @@
         display: flex;
         align-items: center;
       }
+
+      a:hover {
+        border-bottom: 3px solid #fff;
+        transition: all 0.3s ease 0s;
+      }
     }
   }
 }
 
-.header-menu .under-line:hover,
-.active-h {
-  border-bottom: 3px solid #fff;
+.current-h {
+  padding: 8px 16px 8px;
+  border-bottom: 3px solid #da5019;
+}
+
+.menu-link {
+  padding: 8px 16px 11px;
 }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,8 +1,7 @@
 .header {
   padding: 10px 20px;
   height: 80px;
-  background-color: #2e2e2e;
-
+  background-color: #103459;
 
   a {
     color: #fff;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -33,3 +33,8 @@
     }
   }
 }
+
+.header-menu .under-line:hover,
+.active-h {
+  border-bottom: 3px solid #fff;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,15 +19,4 @@ module ApplicationHelper
     range_title = :all unless chart_title.has_key?(range_title)  # 不正な値が入ってきたら、range_titleを:allとする
     chart_title[range_title]
   end
-
-  # header, footerメニュー項目の現在ページを判定
-  # 体重記録のshow, editのとき、footerメニュー項目の体重記録にアンダーラインを引く
-  def check_body_status_request_path(request_path)
-    path_arr = [
-      body_statuses_path, new_body_status_path
-    ]
-    path_arr = edit_body_status_path if controller_name == 'body_statuses' && action_name == 'edit'
-    path_arr = body_status_path if controller_name == 'body_statuses' && action_name == 'show'
-    path_arr.include?(request_path)
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,4 +19,15 @@ module ApplicationHelper
     range_title = :all unless chart_title.has_key?(range_title)  # 不正な値が入ってきたら、range_titleを:allとする
     chart_title[range_title]
   end
+
+  # header, footerメニュー項目の現在ページを判定
+  # 体重記録のshow, editのとき、footerメニュー項目の体重記録にアンダーラインを引く
+  def check_body_status_request_path(request_path)
+    path_arr = [
+      body_statuses_path, new_body_status_path
+    ]
+    path_arr = edit_body_status_path if controller_name == 'body_statuses' && action_name == 'edit'
+    path_arr = body_status_path if controller_name == 'body_statuses' && action_name == 'show'
+    path_arr.include?(request_path)
+  end
 end

--- a/app/views/body_statuses/index.html.erb
+++ b/app/views/body_statuses/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container mt-3">
+<div class="body-statuses-container mt-3">
   <h1 class="page-title">体重記録一覧</h1>
 
   <nav>

--- a/app/views/body_statuses/show.html.erb
+++ b/app/views/body_statuses/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container mt-3">
+<div class="body-statuses-container mt-3">
   <h1 class="page-title mb-4">体重記録の詳細</h1>
 
   <table class="table table-hover table-background">

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container mt-4">
+<div class="charts-container mt-4">
   <% if @exercise_id == '0' %>
     <h2 class="page-title">体重・体脂肪</h2>
   <% else %>

--- a/app/views/partial/_footer.html.erb
+++ b/app/views/partial/_footer.html.erb
@@ -1,14 +1,25 @@
 <footer class="footer fixed-bottom">
-  <div class="container">
-    <nav class="text-muted">
-      <ul class="footer-menu">
-          <li><%= link_to content_tag(:i, '', class: 'fas fa-weight fa-2x footer-icon'), body_statuses_path %></li>
-          <li><%= link_to content_tag(:i, '', class: 'fas fa-chart-line fa-2x ml-4 footer-icon'), charts_path({id: 0, range: 'all', user_id: current_user.id}) %></li>
-          <li><%= link_to content_tag(:i, '', class: 'far fa-file fa-2x ml-4 footer-icon'), workout_logs_path(id: current_user) %></li>
-          <li><%= link_to content_tag(:i, '', class: 'far fa-calendar-alt fa-2x ml-4 footer-icon'), calendar_path(current_user.id) %></li>
-          <li><%= link_to content_tag(:i, '', class: 'fas fa-user-cog fa-2x ml-4 footer-icon'), profile_path(current_user) %></li>
-        </ul>
-      </ul>
-    </nav>
-  </div>
+  <nav>
+    <ul class="footer-menu">
+      <%= link_to body_statuses_path do %>
+        <li class="<%= 'active-f' if check_body_status_request_path(request.path) %>"><i class="fas fa-weight fa-2x footer-icon"></i><span class="content">体重記録</span></li>
+      <% end %>
+
+      <%= link_to charts_path({id: 0, range: 'all', user_id: current_user.id}) do %>
+        <li class="<%= 'active-f' if request.path == charts_path %>"><i class="fas fa-chart-line fa-2x footer-icon"></i><span class="content">グラフ</span></li>
+      <% end %>
+
+      <%= link_to workout_logs_path(id: current_user) do %>
+        <li class="<%= 'active-f' if request.path == workout_logs_path %>"><i class="far fa-clipboard fa-2x footer-icon"></i><span class="content">記録一覧</span></li>
+      <% end %>
+
+      <%= link_to calendar_path(current_user) do %>
+        <li class="<%= 'active-f' if request.path == calendar_path(current_user) %>"><i class="far fa-calendar-alt fa-2x footer-icon"></i><span class="content">カレンダー</span></li>
+      <% end %>
+
+      <%= link_to profile_path(current_user) do %>
+        <li class="<%= 'active-f' if request.path == profile_path(current_user) %>"><i class="fas fa-user-cog fa-2x footer-icon"></i><span class="content">マイページ</span></li>
+      <% end %>
+    </ul>
+  </nav>
 </footer>

--- a/app/views/partial/_footer.html.erb
+++ b/app/views/partial/_footer.html.erb
@@ -1,24 +1,39 @@
 <footer class="footer fixed-bottom">
   <nav>
-    <ul class="footer-menu">
-      <%= link_to body_statuses_path do %>
-        <li class="<%= 'active-f' if check_body_status_request_path(request.path) %>"><i class="fas fa-weight fa-2x footer-icon"></i><span class="content">体重記録</span></li>
+    <ul class="footer-menu mb-1">
+      <%= link_to body_statuses_path, class: 'menu1' do %>
+        <li>
+          <i class="fas fa-weight fa-2x footer-icon"></i>
+          <span class="content">体重記録</span>
+        </li>
       <% end %>
 
-      <%= link_to charts_path({id: 0, range: 'all', user_id: current_user.id}) do %>
-        <li class="<%= 'active-f' if request.path == charts_path %>"><i class="fas fa-chart-line fa-2x footer-icon"></i><span class="content">グラフ</span></li>
+      <%= link_to charts_path({id: 0, range: 'all', user_id: current_user.id}), class: 'menu2' do %>
+        <li>
+          <i class="fas fa-chart-line fa-2x footer-icon"></i>
+          <span class="content">グラフ</span>
+        </li>
       <% end %>
 
-      <%= link_to workout_logs_path(id: current_user) do %>
-        <li class="<%= 'active-f' if request.path == workout_logs_path %>"><i class="far fa-clipboard fa-2x footer-icon"></i><span class="content">記録一覧</span></li>
+      <%= link_to workout_logs_path(id: current_user), class: 'menu3' do %>
+        <li>
+          <i class="far fa-clipboard fa-2x footer-icon">
+          </i><span class="content">記録一覧</span>
+        </li>
       <% end %>
 
-      <%= link_to calendar_path(current_user) do %>
-        <li class="<%= 'active-f' if request.path == calendar_path(current_user) %>"><i class="far fa-calendar-alt fa-2x footer-icon"></i><span class="content">カレンダー</span></li>
+      <%= link_to calendar_path(current_user), class: 'menu4' do %>
+        <li>
+          <i class="far fa-calendar-alt fa-2x footer-icon"></i>
+          <span class="content">カレンダー</span>
+        </li>
       <% end %>
 
-      <%= link_to profile_path(current_user) do %>
-        <li class="<%= 'active-f' if request.path == profile_path(current_user) %>"><i class="fas fa-user-cog fa-2x footer-icon"></i><span class="content">マイページ</span></li>
+      <%= link_to profile_path(current_user), class: 'menu5' do %>
+        <li>
+          <i class="fas fa-user-cog fa-2x footer-icon"></i>
+          <span class="content">マイページ</span>
+        </li>
       <% end %>
     </ul>
   </nav>

--- a/app/views/partial/_header.html.erb
+++ b/app/views/partial/_header.html.erb
@@ -5,11 +5,11 @@
       <li class="header-menu-user-name"><%= image_tag set_image(current_user.profile.icon, 'default_user_icon.png'), class: 'cover50 mr-2' %> <%= link_to current_user.name, profile_path(current_user) %>
       <li>
         <ul class="header-menu-inner">
-          <li class="under-line mr-2"><%= link_to '管理画面', '/admin', class: 'nav-link' if current_user.try(:admin?) %></li>
-          <li class="under-line mr-2 <%= 'active-h' if request.path == menus_path %>"><%= link_to 'トレーニング', menus_path, class: 'nav-link' %></li>
-          <li class="under-line mr-2 <%= 'active-h' if request.path == exercises_path %>"><%= link_to '種目', exercises_path, class: 'nav-link' %></li>
-          <li class="under-line mr-2 <%= 'active-h' if request.path == profiles_path %>"><%= link_to 'ユーザー', profiles_path, class: 'nav-link' %></li>
-          <li class="under-line mr-2 <%= 'active-h' if request.path == posts_path %>"><%= link_to '投稿', posts_path, class: 'nav-link' %></li>
+          <li class="mr-2"><%= link_to '管理画面', '/admin', class: 'menu-link' if current_user.try(:admin?) %></li>
+          <li class="mr-2"><%= link_to 'トレーニング', menus_path, class: 'menu-link menu1' %></li>
+          <li class="mr-2"><%= link_to '種目', exercises_path, class: 'menu-link menu2' %></li>
+          <li class="mr-2"><%= link_to 'ユーザー', profiles_path, class: 'menu-link menu3' %></li>
+          <li class="mr-2"><%= link_to '投稿', posts_path, class: 'menu-link menu4' %></li>
         </ul>
       </li>
     </ul>

--- a/app/views/partial/_header.html.erb
+++ b/app/views/partial/_header.html.erb
@@ -5,11 +5,11 @@
       <li class="header-menu-user-name"><%= image_tag set_image(current_user.profile.icon, 'default_user_icon.png'), class: 'cover50 mr-2' %> <%= link_to current_user.name, profile_path(current_user) %>
       <li>
         <ul class="header-menu-inner">
-          <li><%= link_to '管理画面', '/admin', class: 'nav-link' if current_user.try(:admin?) %></li>
-          <li><%= link_to 'トレーニング', menus_path, class: 'nav-link' %></li>
-          <li><%= link_to '種目', exercises_path, class: 'nav-link' %></li>
-          <li><%= link_to 'ユーザー', profiles_path, class: 'nav-link' %></li>
-          <li><%= link_to '投稿', posts_path, class: 'nav-link' %></li>
+          <li class="under-line mr-2"><%= link_to '管理画面', '/admin', class: 'nav-link' if current_user.try(:admin?) %></li>
+          <li class="under-line mr-2 <%= 'active-h' if request.path == menus_path %>"><%= link_to 'トレーニング', menus_path, class: 'nav-link' %></li>
+          <li class="under-line mr-2 <%= 'active-h' if request.path == exercises_path %>"><%= link_to '種目', exercises_path, class: 'nav-link' %></li>
+          <li class="under-line mr-2 <%= 'active-h' if request.path == profiles_path %>"><%= link_to 'ユーザー', profiles_path, class: 'nav-link' %></li>
+          <li class="under-line mr-2 <%= 'active-h' if request.path == posts_path %>"><%= link_to '投稿', posts_path, class: 'nav-link' %></li>
         </ul>
       </li>
     </ul>

--- a/app/views/partial/_header.html.erb
+++ b/app/views/partial/_header.html.erb
@@ -6,9 +6,9 @@
       <li>
         <ul class="header-menu-inner">
           <li><%= link_to '管理画面', '/admin', class: 'nav-link' if current_user.try(:admin?) %></li>
-          <li><%= link_to 'トレーニングメニュー', menus_path, class: 'nav-link' %></li>
-          <li><%= link_to '種目メニュー', exercises_path, class: 'nav-link' %></li>
-          <li><%= link_to 'ユーザー一覧', profiles_path, class: 'nav-link' %></li>
+          <li><%= link_to 'トレーニング', menus_path, class: 'nav-link' %></li>
+          <li><%= link_to '種目', exercises_path, class: 'nav-link' %></li>
+          <li><%= link_to 'ユーザー', profiles_path, class: 'nav-link' %></li>
           <li><%= link_to '投稿', posts_path, class: 'nav-link' %></li>
         </ul>
       </li>


### PR DESCRIPTION
#134 

## header
- 背景色を#103459へ変更
- 現在ページのメニュー項目に、border-bottomをつけてわかりやすくする。colorは#da5019。
- メニュー項目にhover時、border-bottomをつける。colorは#fff。
- メニュー項目の文言を一部変更。トレーニングメニュー -> トレーニング、種目メニュー -> 種目、ユーザー一覧 -> ユーザー

![スクリーンショット 2020-06-27 0 30 23](https://user-images.githubusercontent.com/50142017/85874462-a1641d80-b80d-11ea-8a67-bc46a25ab559.png)

## footer

- footerメニューのアイコン下に、項目名を追加
- 記録一覧のアイコンを i class="far fa-clipboard"に変更
- 現在ページのメニュー項目に、border-bottomをつけてわかりやすくする。colorは#da5019。
- メニュー項目にhover時、border-bottomをつける。colorは#333。
![スクリーンショット 2020-06-27 0 31 47](https://user-images.githubusercontent.com/50142017/85874869-3ff07e80-b80e-11ea-9bcf-5265b86d0428.png)
