### PR TITLE
【Fixed】 Rspecの修正

### DIFF
--- a/spec/system/exercises_spec.rb
+++ b/spec/system/exercises_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'トレーニング種目', type: :system do
       fill_in 'パスワード', with: login_user.password
       click_on 'ログイン'
       sleep 0.5
-      click_on '種目メニュー'
+      click_on '種目'
     end
 
     describe '一覧表示' do

--- a/spec/system/follows_spec.rb
+++ b/spec/system/follows_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'ユーザーのフォロー機能', type: :system do
         let(:login_user) { user_a }
 
         before do
-          click_on 'ユーザー一覧'
+          click_on 'ユーザー'
           click_on 'フォローする'
           visit profile_path(user_a)
           click_on 'フォロー中'
@@ -34,7 +34,7 @@ RSpec.describe 'ユーザーのフォロー機能', type: :system do
         let(:login_user) { user_b }
 
         before do
-          click_on 'ユーザー一覧'
+          click_on 'ユーザー'
           click_on 'フォローする'
           visit profile_path(user_b)
           click_on 'フォロー中'

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'ユーザー機能', type: :system do
       before do
         @user_b = create(:user, name: 'ユーザーB', email: 'b@test.com')
         create(:profile, user: @user_b)
-        click_on 'ユーザー一覧'
+        click_on 'ユーザー'
       end
 
       it '他のユーザーが表示されていること' do


### PR DESCRIPTION
#137 

Rspecで発生していた以下のエラーを修正しました

- rspec ./spec/system/exercises_spec.rb:22 # トレーニング種目 管理機能 一覧表示 種目メニューをクリックしたとき プリセットタブで種目が表示されていること

- rspec ./spec/system/exercises_spec.rb:43 # トレーニング種目 管理機能 新規作成 種目を作成したとき 種目が登録されること

- rspec ./spec/system/exercises_spec.rb:58 # トレーニング種目 管理機能 詳細表示 種目のリンクを押したとき 詳細画面を表示できること

- rspec ./spec/system/exercises_spec.rb:77 # トレーニング種目 管理機能 編集 システム管理者がログインしているとき プリセットの種目を編集できること

- rspec ./spec/system/exercises_spec.rb:89 # トレーニング種目 管理機能 編集 一般ユーザーがログインしているとき プリセットの種目を編集できないこと

- rspec ./spec/system/exercises_spec.rb:104 # トレーニング種目 管理機能 削除 削除ボタンを押したとき 種目を削除できること

- rspec ./spec/system/follows_spec.rb:28 # ユーザーのフォロー機能 管理機能 フォロー/フォロー解除 フォローリンクを押したとき フォローしたユーザーが表示されていること

- rspec ./spec/system/follows_spec.rb:46 # ユーザーのフォロー機能 管理機能 フォロー/フォロー解除 フォロー解除リンクを押したとき フォロー解除したユーザーが表示されていないこと

- rspec ./spec/system/users_spec.rb:137 # ユーザー機能 ログイン機能 ログイン後にユーザー一覧をクリックしたとき 他のユーザーが表示されていること