### PR TITLE
【Fixed】種目検索を実行するとエラーになるので修正する

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -38,15 +38,8 @@ class ExercisesController < ApplicationController
 
   def search
     @search_params = exercise_search_params
-    @exercises_preset = Exercise.exercise_search(@search_params)
-
-    # if @search_params[:name].blank? && @search_params[:part].blank? && @search_params[:category].blank?
-    #   set_exercise_preset_and_original
-    # else
-      # @search_params[:preset] = true
-      # @exercises_preset = Exercise.exercise_search(@search_params)
-    # end
-
+    @exercises_preset = Exercise.exercise_search_preset(@search_params)
+    @exercises_original = Exercise.exercise_search_original(@search_params)
     render :index
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -29,10 +29,19 @@ class Exercise < ApplicationRecord
   scope :preset, -> { where(preset: true) }
   scope :original, -> (current_user) { where(preset: false).where(user_id: current_user.id) }
 
-  scope :exercise_search, -> (search_params) do
+  scope :exercise_search_preset, -> (search_params) do
     return if search_params.blank?
 
     where(preset: true)
+      .name_like(search_params[:name])
+      .part_is(search_params[:part])
+      .category_is(search_params[:category])
+  end
+
+  scope :exercise_search_original, -> (search_params) do
+    return if search_params.blank?
+
+    where(preset: false)
       .name_like(search_params[:name])
       .part_is(search_params[:part])
       .category_is(search_params[:category])


### PR DESCRIPTION
#139 

- 検索実行時、オリジナル種目のデータが存在しなかったので正しく取得できるよう改善しました
- 不要コメントコードの削除