### PR TITLE
【Fixed】トレーニング種目のグラフ表示エラーの修正

### DIFF
--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -34,11 +34,21 @@ class Workout < ApplicationRecord
   end
 
   scope :get_chart_min, -> (user, exercise_id, range, column) do
-    find_workout(user, exercise_id, range).pluck(column).min - 1
+    arr = find_workout(user, exercise_id, range).pluck(column)
+    unless arr.empty?
+      arr.min - 1
+    else
+      0
+    end
   end
 
   scope :get_chart_max, -> (user, exercise_id, range, column) do
-    find_workout(user, exercise_id, range).pluck(column).max + 1
+    arr = find_workout(user, exercise_id, range).pluck(column)
+    unless arr.empty?
+      arr.max + 1
+    else
+      0
+    end
   end
 
   private

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -17,9 +17,10 @@
         chart_values: @chart_values
       } %>
     <% else %>
-      <p class="text-center mt-4">データが存在しません</p>
+      <%= render 'partial/chart_no_data' %>
     <% end %>
   <% else %>
+    <% unless @chart_values.has_value?(0) %>
   <!-- トレーニングのグラフ -->
     <%= render 'partial/chart_workout', {
       range_title: @range_title,
@@ -27,6 +28,9 @@
       chart_records: @chart_records,
       chart_values: @chart_values
     } %>
+    <% else %>
+      <%= render 'partial/chart_no_data' %>
+    <% end %>
   <% end %>
 
   <!-- 表示期間のリンク -->

--- a/app/views/partial/_chart_no_data.html.erb
+++ b/app/views/partial/_chart_no_data.html.erb
@@ -1,0 +1,1 @@
+<p class="text-center mt-4">データが存在しません</p>


### PR DESCRIPTION
#141 

- グラフの指定した期間にデータが存在しない場合にエラーとなっていたので、その場合にはデータが存在しませんというメッセージを表示するようにしました
![スクリーンショット 2020-06-27 22 52 41](https://user-images.githubusercontent.com/50142017/85923902-c74ef800-b8c9-11ea-9514-f5dab567e6c8.png)
