### PR TITLE
【Fixed】トレーニング種目グラフの画面から、体重・体脂肪グラフの画面へのリンクを設置する

### DIFF
--- a/app/views/partial/_chart_workout_links.html.erb
+++ b/app/views/partial/_chart_workout_links.html.erb
@@ -1,5 +1,6 @@
 <nav>
   <ul class="exercise-chart-nav mt-4">
+    <li><%= link_to '体重/体脂肪', charts_path({id: 0, range: 'all', user_id: current_user.id}), class: 'text-white' %></li>
     <% @workouts.each do |workout| %>
       <li><%= link_to workout.exercise.name, charts_path({ id: workout.exercise_id, range: 'all', user_id: user_id }), class: 'text-white' %></li>
     <% end %>


### PR DESCRIPTION
#144 

- 表示期間選択リンクの下にある種目グラフへのリンクの一番左側に、体重・体脂肪グラフへのリンクを設置した
![スクリーンショット 2020-06-29 23 05 22](https://user-images.githubusercontent.com/50142017/86016287-8f78b980-ba5d-11ea-9b73-e1e8db84813e.png)
